### PR TITLE
Add id field to envelope

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -44,6 +44,7 @@ Envelope wraps an Event and adds metadata.
 | deployment | [string](#string) | optional | Deployment name (used to uniquely identify source). |
 | job | [string](#string) | optional | Job name (used to uniquely identify source). |
 | index | [string](#string) | optional | Index of job (used to uniquely identify source). |
+| id | [string](#string) | optional | Id of job instance (used to uniquely identify source). |
 | ip | [string](#string) | optional | IP address (used to uniquely identify source). |
 | tags | [Envelope.TagsEntry](#events.Envelope.TagsEntry) | repeated | key/value tags to include additional identifying information. |
 | httpStart | [HttpStart](#events.HttpStart) | optional |  |

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -30,6 +30,7 @@ message Envelope {
     optional string deployment = 13;          /// Deployment name (used to uniquely identify source).
     optional string job = 14;                 /// Job name (used to uniquely identify source).
     optional string index = 15;               /// Index of job (used to uniquely identify source).
+    optional string id = 18;                  /// Id of job instance (used to uniquely identify source).
     optional string ip = 16;                  /// IP address (used to uniquely identify source).
 
     map<string, string> tags = 17;            /// key/value tags to include additional identifying information.
@@ -44,4 +45,3 @@ message Envelope {
     optional Error error = 11;
     optional ContainerMetric containerMetric = 12;
 }
-


### PR DESCRIPTION
Added `id` field to envelope. We want to correlate metrics from BOSH with metrics emitted by the metron agent. As BOSH metrics already contain the job instance id (https://bosh.io/docs/jobs.html#properties-spec, `spec.id`), we need to enhance the metron agent to include this field as well. Therefore - as a first step - we have added this new field to the dropsonde envelope.
