### PR TITLE
fixes generate-java.sh bug

### DIFF
--- a/generate-java.sh
+++ b/generate-java.sh
@@ -2,9 +2,9 @@
 
 dir_resolve()
 {
-"$1"!="" && mkdir -p "$1"
-cd "$1" 2>/dev/null || return $?  # cd to desired directory; if fail, quell any error messages but return exit status
-echo "`pwd -P`" # output full, link-resolved path
+    [ "$1" != "" ] && mkdir -p "$1"
+    cd "$1" 2>/dev/null || return $?  # cd to desired directory; if fail, quell any error messages but return exit status
+    echo "`pwd -P`" # output full, link-resolved path
 }
 
 set -e


### PR DESCRIPTION
the lack of spaces and brackets causes:

```
./dropsonde-protocol/generate-java.sh: line 5: protobuf!=: command not found
```
