### PR TITLE
Feat: protobuf syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or, from the base directory, where `$DST_DIR` is the desired destination:
 ```
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 protoc -I=events --go_out=. events/*.proto
-mv github.com/cloudfoundry/dropsonde/events/*.pb.go $DST_DIR
+mv github.com/cloudfoundry/sonde-go/events/*.pb.go $DST_DIR
 rm -rf github.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ brew install protobuf
 
 The [Sonde-Go](https://github.com/cloudfoundry/sonde-go) library can be used instead.
 
-Or, from the base directory, where `$DST_DIR` is the desired destination:
+Or, from your working directory, where `$DST_DIR` is the desired destination:
 ```
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-protoc --go_out=. events/*.proto
+protoc --go_out=. dropsonde-protocol/events/*.proto
 mv github.com/cloudfoundry/sonde-go/events/*.pb.go $DST_DIR
 rm -rf github.com
 ```
 
 ### Java
 
-From the base directory, where `$DST_DIR` is the desired destination:
+From your working directory, where `$DST_DIR` is the desired destination:
 ```
-protoc --java_out=. events/*.proto
+protoc --java_out=. dropsonde-protocol/events/*.proto
 mv org/cloudfoundry/dropsonde/events/*.java $DST_DIR
 rm -rf org
 ```
@@ -60,9 +60,9 @@ Please see [this list](https://github.com/protocolbuffers/protobuf/blob/master/d
 
 ### Message documentation
 
-Each package's documentation is auto-generated with [protoc-gen-doc](https://github.com/estan/protoc-gen-doc). After installing the tool, run:
+Each package's documentation is auto-generated with [protoc-gen-doc](https://github.com/estan/protoc-gen-doc). After installing the tool, run the following from your working directory:
 ```
-protoc --doc_out=markdown,README.md:events events/*.proto
+protoc --doc_out=markdown,README.md:dropsonde-protocol/events dropsonde-protocol/events/*.proto
 ```
 
 ## Communication protocols

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The [Sonde-Go](https://github.com/cloudfoundry/sonde-go) library can be used ins
 Or, from the base directory, where `$DST_DIR` is the desired destination:
 ```
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-protoc -I=events --go_out=. events/*.proto
+protoc --go_out=. events/*.proto
 mv github.com/cloudfoundry/sonde-go/events/*.pb.go $DST_DIR
 rm -rf github.com
 ```
@@ -47,7 +47,7 @@ rm -rf github.com
 
 From the base directory, where `$DST_DIR` is the desired destination:
 ```
-protoc -I=events --java_out=. events/*.proto
+protoc --java_out=. events/*.proto
 mv org/cloudfoundry/dropsonde/events/*.java $DST_DIR
 rm -rf org
 ```
@@ -62,8 +62,7 @@ Please see [this list](https://github.com/protocolbuffers/protobuf/blob/master/d
 
 Each package's documentation is auto-generated with [protoc-gen-doc](https://github.com/estan/protoc-gen-doc). After installing the tool, run:
 ```
-cd events
-protoc --doc_out=markdown,README.md:. *.proto
+protoc --doc_out=markdown,README.md:events events/*.proto
 ```
 
 ## Communication protocols

--- a/README.md
+++ b/README.md
@@ -20,26 +20,43 @@ Please see the following for detailed descriptions of each type:
 
 ## Generating code
 
-Note: Due to [maps not being supported in protoc v2.X](https://github.com/google/protobuf/issues/799#issuecomment-138207911), the proto definitions in this repository require protoc v3.0.0 or higher.
+### Setup
+
+Install protobuf.
+
+*Note: Due to [maps not being supported in protoc v2.X](https://github.com/google/protobuf/issues/799#issuecomment-138207911), the proto definitions in this repository require protoc v3.0.0 or higher.*
+
+On mac:
+```
+brew install protobuf
+```
 
 ### Go
 
-Code generation for Go has moved to the [Sonde-Go](https://github.com/cloudfoundry/sonde-go) library.
+The [Sonde-Go](https://github.com/cloudfoundry/sonde-go) library can be used instead.
+
+Or, from the base directory, where `$DST_DIR` is the desired destination:
+```
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+protoc -I=events --go_out=. events/*.proto
+mv github.com/cloudfoundry/dropsonde/events/*.pb.go $DST_DIR
+rm -rf github.com
+```
 
 ### Java
 
-1. Build the go code first (see above) so that all the imports are available
-
-2. Generate the Java code (optionally providing a target path as a directory)
-   ```
-   ./generate-java.sh [TARGET_PATH]
-   ```
+From the base directory, where `$DST_DIR` is the desired destination:
+```
+protoc -I=events --java_out=. events/*.proto
+mv org/cloudfoundry/dropsonde/events/*.java $DST_DIR
+rm -rf org
+```
 
 ### Other languages
 
 For C++ and Python, Google provides [tutorials](https://developers.google.com/protocol-buffers/docs/tutorials).
 
-Please see [this list](https://github.com/google/protobuf/wiki/Third-Party-Add-ons#Programming_Languages) for working with protocol buffers in other languages.
+Please see [this list](https://github.com/protocolbuffers/protobuf/blob/master/docs/third_party.md) for working with protocol buffers in other languages.
 
 ### Message documentation
 

--- a/events/README.md
+++ b/events/README.md
@@ -1,58 +1,80 @@
 # Protocol Documentation
-<a name="top"/>
+<a name="top"></a>
 
 ## Table of Contents
-* [envelope.proto](#envelope.proto)
- * [Envelope](#events.Envelope)
- * [Envelope.TagsEntry](#events.Envelope.TagsEntry)
- * [Envelope.EventType](#events.Envelope.EventType)
-* [error.proto](#error.proto)
- * [Error](#events.Error)
-* [http.proto](#http.proto)
- * [HttpStartStop](#events.HttpStartStop)
- * [Method](#events.Method)
- * [PeerType](#events.PeerType)
-* [log.proto](#log.proto)
- * [LogMessage](#events.LogMessage)
- * [LogMessage.MessageType](#events.LogMessage.MessageType)
-* [metric.proto](#metric.proto)
- * [ContainerMetric](#events.ContainerMetric)
- * [CounterEvent](#events.CounterEvent)
- * [ValueMetric](#events.ValueMetric)
-* [uuid.proto](#uuid.proto)
- * [UUID](#events.UUID)
-* [Scalar Value Types](#scalar-value-types)
 
-<a name="envelope.proto"/>
+- [envelope.proto](#envelope-proto)
+    - [Envelope](#events-Envelope)
+    - [Envelope.TagsEntry](#events-Envelope-TagsEntry)
+  
+    - [Envelope.EventType](#events-Envelope-EventType)
+  
+- [error.proto](#error-proto)
+    - [Error](#events-Error)
+  
+- [http.proto](#http-proto)
+    - [HttpStartStop](#events-HttpStartStop)
+  
+    - [Method](#events-Method)
+    - [PeerType](#events-PeerType)
+  
+- [log.proto](#log-proto)
+    - [LogMessage](#events-LogMessage)
+  
+    - [LogMessage.MessageType](#events-LogMessage-MessageType)
+  
+- [metric.proto](#metric-proto)
+    - [ContainerMetric](#events-ContainerMetric)
+    - [CounterEvent](#events-CounterEvent)
+    - [ValueMetric](#events-ValueMetric)
+  
+- [uuid.proto](#uuid-proto)
+    - [UUID](#events-UUID)
+  
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="envelope-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## envelope.proto
 
 
+
+<a name="events-Envelope"></a>
+
 ### Envelope
-<a name="events.Envelope"/>
 Envelope wraps an Event and adds metadata.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | origin | [string](#string) | required | Unique description of the origin of this event. |
-| eventType | [Envelope.EventType](#events.Envelope.EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
+| eventType | [Envelope.EventType](#events-Envelope-EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
 | timestamp | [int64](#int64) | optional | UNIX timestamp (in nanoseconds) event was wrapped in this Envelope. |
 | deployment | [string](#string) | optional | Deployment name (used to uniquely identify source). |
 | job | [string](#string) | optional | Job name (used to uniquely identify source). |
 | index | [string](#string) | optional | Index of job (used to uniquely identify source). |
 | ip | [string](#string) | optional | IP address (used to uniquely identify source). |
-| tags | [Envelope.TagsEntry](#events.Envelope.TagsEntry) | repeated | key/value tags to include additional identifying information. |
-| httpStartStop | [HttpStartStop](#events.HttpStartStop) | optional |  |
-| logMessage | [LogMessage](#events.LogMessage) | optional |  |
-| valueMetric | [ValueMetric](#events.ValueMetric) | optional |  |
-| counterEvent | [CounterEvent](#events.CounterEvent) | optional |  |
-| error | [Error](#events.Error) | optional |  |
-| containerMetric | [ContainerMetric](#events.ContainerMetric) | optional |  |
+| tags | [Envelope.TagsEntry](#events-Envelope-TagsEntry) | repeated | key/value tags to include additional identifying information. |
+| httpStartStop | [HttpStartStop](#events-HttpStartStop) | optional |  |
+| logMessage | [LogMessage](#events-LogMessage) | optional |  |
+| valueMetric | [ValueMetric](#events-ValueMetric) | optional |  |
+| counterEvent | [CounterEvent](#events-CounterEvent) | optional |  |
+| error | [Error](#events-Error) | optional |  |
+| containerMetric | [ContainerMetric](#events-ContainerMetric) | optional |  |
 
+
+
+
+
+
+<a name="events-Envelope-TagsEntry"></a>
 
 ### Envelope.TagsEntry
-<a name="events.Envelope.TagsEntry"/>
+
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -61,8 +83,14 @@ Envelope wraps an Event and adds metadata.
 
 
 
+
+
+ 
+
+
+<a name="events-Envelope-EventType"></a>
+
 ### Envelope.EventType
-<a name="events.Envelope.EventType"/>
 Type of the wrapped event.
 
 | Name | Number | Description |
@@ -75,16 +103,26 @@ Type of the wrapped event.
 | ContainerMetric | 9 |  |
 
 
+ 
+
+ 
+
+ 
+
+
+
+<a name="error-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## error.proto
-<a name="error.proto"/>
 
 
+
+<a name="events-Error"></a>
 
 ### Error
-<a name="events.Error"/>
 An Error event represents an error in the originating process.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -93,38 +131,59 @@ An Error event represents an error in the originating process.
 | message | [string](#string) | required | Error description (preferably human-readable). |
 
 
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="http-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## http.proto
-<a name="http.proto"/>
 
 
+
+<a name="events-HttpStartStop"></a>
 
 ### HttpStartStop
-<a name="events.HttpStartStop"/>
 An HttpStartStop event represents the whole lifecycle of an HTTP request.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | startTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was sent (by a client) or received (by a server). |
 | stopTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was received. |
-| requestId | [UUID](#events.UUID) | required | ID for tracking lifecycle of request. |
-| peerType | [PeerType](#events.PeerType) | required | Role of the emitting process in the request cycle. |
-| method | [Method](#events.Method) | required | Method of the request. |
+| requestId | [UUID](#events-UUID) | required | ID for tracking lifecycle of request. |
+| peerType | [PeerType](#events-PeerType) | required | Role of the emitting process in the request cycle. |
+| method | [Method](#events-Method) | required | Method of the request. |
 | uri | [string](#string) | required | Destination of the request. |
 | remoteAddress | [string](#string) | required | Remote address of the request. (For a server, this should be the origin of the request.) |
 | userAgent | [string](#string) | required | Contents of the UserAgent header on the request. |
 | statusCode | [int32](#int32) | required | Status code returned with the response to the request. |
 | contentLength | [int64](#int64) | required | Length of response (bytes). |
-| applicationId | [UUID](#events.UUID) | optional | If this request was made in relation to an appliciation, this field should track that application's ID. |
+| applicationId | [UUID](#events-UUID) | optional | If this request was made in relation to an appliciation, this field should track that application&#39;s ID. |
 | instanceIndex | [int32](#int32) | optional | Index of the application instance. |
 | instanceId | [string](#string) | optional | ID of the application instance. |
 | forwarded | [string](#string) | repeated | This contains http forwarded-for [x-forwarded-for] header from the request. |
 
 
 
+
+
+ 
+
+
+<a name="events-Method"></a>
+
 ### Method
-<a name="events.Method"/>
 HTTP method.
 
 | Name | Number | Description |
@@ -174,8 +233,11 @@ HTTP method.
 | UPDATEREDIRECTREF | 43 |  |
 | VERSION_CONTROL | 44 |  |
 
+
+
+<a name="events-PeerType"></a>
+
 ### PeerType
-<a name="events.PeerType"/>
 Type of peer handling request.
 
 | Name | Number | Description |
@@ -184,32 +246,46 @@ Type of peer handling request.
 | Server | 2 | Request is received by this process. |
 
 
+ 
+
+ 
+
+ 
 
 
+
+<a name="log-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## log.proto
-<a name="log.proto"/>
 
 
+
+<a name="events-LogMessage"></a>
 
 ### LogMessage
-<a name="events.LogMessage"/>
-A LogMessage contains a &quot;log line&quot; and associated metadata.
+A LogMessage contains a &#34;log line&#34; and associated metadata.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | message | [bytes](#bytes) | required | Bytes of the log message. (Note that it is not required to be a single line.) |
-| message_type | [LogMessage.MessageType](#events.LogMessage.MessageType) | required | Type of the message (OUT or ERR). |
+| message_type | [LogMessage.MessageType](#events-LogMessage-MessageType) | required | Type of the message (OUT or ERR). |
 | timestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the log was written. |
 | app_id | [string](#string) | optional | Application that emitted the message (or to which the application is related). |
-| source_type | [string](#string) | optional | Source of the message. For Cloud Foundry, this can be &quot;APP&quot;, &quot;RTR&quot;, &quot;DEA&quot;, &quot;STG&quot;, etc. |
+| source_type | [string](#string) | optional | Source of the message. For Cloud Foundry, this can be &#34;APP&#34;, &#34;RTR&#34;, &#34;DEA&#34;, &#34;STG&#34;, etc. |
 | source_instance | [string](#string) | optional | Instance that emitted the message. |
 
 
 
+
+
+ 
+
+
+<a name="events-LogMessage-MessageType"></a>
+
 ### LogMessage.MessageType
-<a name="events.LogMessage.MessageType"/>
 MessageType stores the destination of the message (corresponding to STDOUT or STDERR).
 
 | Name | Number | Description |
@@ -218,18 +294,26 @@ MessageType stores the destination of the message (corresponding to STDOUT or ST
 | ERR | 2 |  |
 
 
+ 
+
+ 
+
+ 
 
 
+
+<a name="metric-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## metric.proto
-<a name="metric.proto"/>
 
 
+
+<a name="events-ContainerMetric"></a>
 
 ### ContainerMetric
-<a name="events.ContainerMetric"/>
 A ContainerMetric records resource usage of an app in a container.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -242,9 +326,17 @@ A ContainerMetric records resource usage of an app in a container.
 | diskBytesQuota | [uint64](#uint64) | optional | Maximum bytes of disk allocated to container. |
 
 
+
+
+
+
+<a name="events-CounterEvent"></a>
+
 ### CounterEvent
-<a name="events.CounterEvent"/>
-A CounterEvent represents the increment of a counter. It contains only the change in the value; it is the responsibility of downstream consumers to maintain the value of the counter.
+A CounterEvent represents the increment of a counter. It contains only the
+change in the value; it is the responsibility of downstream consumers to
+maintain the value of the counter.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -253,9 +345,15 @@ A CounterEvent represents the increment of a counter. It contains only the chang
 | total | [uint64](#uint64) | optional | Total value of the counter. This will be overridden by Metron, which internally tracks the total of each named Counter it receives. |
 
 
+
+
+
+
+<a name="events-ValueMetric"></a>
+
 ### ValueMetric
-<a name="events.ValueMetric"/>
 A ValueMetric indicates the value of a metric at an instant in time.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -267,19 +365,32 @@ A ValueMetric indicates the value of a metric at an instant in time.
 
 
 
+ 
 
+ 
+
+ 
+
+ 
+
+
+
+<a name="uuid-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## uuid.proto
-<a name="uuid.proto"/>
 
 
+
+<a name="events-UUID"></a>
 
 ### UUID
-<a name="events.UUID"/>
 Type representing a 128-bit UUID.
 
-The bytes of the UUID should be packed in little-endian **byte** (not bit) order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
+The bytes of the UUID should be packed in little-endian **byte** (not bit)
+order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should
+be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -290,27 +401,33 @@ The bytes of the UUID should be packed in little-endian **byte** (not bit) order
 
 
 
+ 
+
+ 
+
+ 
+
+ 
+
 
 
 ## Scalar Value Types
-<a name="scalar-value-types"/>
 
-| .proto Type | Notes | C++ Type | Java Type | Python Type |
-| ----------- | ----- | -------- | --------- | ----------- |
-| <a name="double"/> double |  | double | double | float |
-| <a name="float"/> float |  | float | float | float |
-| <a name="int32"/> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int |
-| <a name="int64"/> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long |
-| <a name="uint32"/> uint32 | Uses variable-length encoding. | uint32 | int | int/long |
-| <a name="uint64"/> uint64 | Uses variable-length encoding. | uint64 | long | int/long |
-| <a name="sint32"/> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int |
-| <a name="sint64"/> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long |
-| <a name="fixed32"/> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int |
-| <a name="fixed64"/> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long |
-| <a name="sfixed32"/> sfixed32 | Always four bytes. | int32 | int | int |
-| <a name="sfixed64"/> sfixed64 | Always eight bytes. | int64 | long | int/long |
-| <a name="bool"/> bool |  | bool | boolean | boolean |
-| <a name="string"/> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
-| <a name="bytes"/> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
 
-<p align="right"><a href="#top">Top</a></p>

--- a/events/README.md
+++ b/events/README.md
@@ -3,46 +3,46 @@
 
 ## Table of Contents
 
-- [envelope.proto](#envelope-proto)
-    - [Envelope](#events-Envelope)
-    - [Envelope.TagsEntry](#events-Envelope-TagsEntry)
+- [events/envelope.proto](#events/envelope.proto)
+    - [Envelope](#events.Envelope)
+    - [Envelope.TagsEntry](#events.Envelope.TagsEntry)
   
-    - [Envelope.EventType](#events-Envelope-EventType)
+    - [Envelope.EventType](#events.Envelope.EventType)
   
-- [error.proto](#error-proto)
-    - [Error](#events-Error)
+- [events/error.proto](#events/error.proto)
+    - [Error](#events.Error)
   
-- [http.proto](#http-proto)
-    - [HttpStartStop](#events-HttpStartStop)
+- [events/http.proto](#events/http.proto)
+    - [HttpStartStop](#events.HttpStartStop)
   
-    - [Method](#events-Method)
-    - [PeerType](#events-PeerType)
+    - [Method](#events.Method)
+    - [PeerType](#events.PeerType)
   
-- [log.proto](#log-proto)
-    - [LogMessage](#events-LogMessage)
+- [events/log.proto](#events/log.proto)
+    - [LogMessage](#events.LogMessage)
   
-    - [LogMessage.MessageType](#events-LogMessage-MessageType)
+    - [LogMessage.MessageType](#events.LogMessage.MessageType)
   
-- [metric.proto](#metric-proto)
-    - [ContainerMetric](#events-ContainerMetric)
-    - [CounterEvent](#events-CounterEvent)
-    - [ValueMetric](#events-ValueMetric)
+- [events/metric.proto](#events/metric.proto)
+    - [ContainerMetric](#events.ContainerMetric)
+    - [CounterEvent](#events.CounterEvent)
+    - [ValueMetric](#events.ValueMetric)
   
-- [uuid.proto](#uuid-proto)
-    - [UUID](#events-UUID)
+- [events/uuid.proto](#events/uuid.proto)
+    - [UUID](#events.UUID)
   
 - [Scalar Value Types](#scalar-value-types)
 
 
 
-<a name="envelope-proto"></a>
+<a name="events/envelope.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## envelope.proto
+## events/envelope.proto
 
 
 
-<a name="events-Envelope"></a>
+<a name="events.Envelope"></a>
 
 ### Envelope
 Envelope wraps an Event and adds metadata.
@@ -51,26 +51,26 @@ Envelope wraps an Event and adds metadata.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | origin | [string](#string) | required | Unique description of the origin of this event. |
-| eventType | [Envelope.EventType](#events-Envelope-EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
+| eventType | [Envelope.EventType](#events.Envelope.EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
 | timestamp | [int64](#int64) | optional | UNIX timestamp (in nanoseconds) event was wrapped in this Envelope. |
 | deployment | [string](#string) | optional | Deployment name (used to uniquely identify source). |
 | job | [string](#string) | optional | Job name (used to uniquely identify source). |
 | index | [string](#string) | optional | Index of job (used to uniquely identify source). |
 | ip | [string](#string) | optional | IP address (used to uniquely identify source). |
-| tags | [Envelope.TagsEntry](#events-Envelope-TagsEntry) | repeated | key/value tags to include additional identifying information. |
-| httpStartStop | [HttpStartStop](#events-HttpStartStop) | optional |  |
-| logMessage | [LogMessage](#events-LogMessage) | optional |  |
-| valueMetric | [ValueMetric](#events-ValueMetric) | optional |  |
-| counterEvent | [CounterEvent](#events-CounterEvent) | optional |  |
-| error | [Error](#events-Error) | optional |  |
-| containerMetric | [ContainerMetric](#events-ContainerMetric) | optional |  |
+| tags | [Envelope.TagsEntry](#events.Envelope.TagsEntry) | repeated | key/value tags to include additional identifying information. |
+| httpStartStop | [HttpStartStop](#events.HttpStartStop) | optional |  |
+| logMessage | [LogMessage](#events.LogMessage) | optional |  |
+| valueMetric | [ValueMetric](#events.ValueMetric) | optional |  |
+| counterEvent | [CounterEvent](#events.CounterEvent) | optional |  |
+| error | [Error](#events.Error) | optional |  |
+| containerMetric | [ContainerMetric](#events.ContainerMetric) | optional |  |
 
 
 
 
 
 
-<a name="events-Envelope-TagsEntry"></a>
+<a name="events.Envelope.TagsEntry"></a>
 
 ### Envelope.TagsEntry
 
@@ -88,7 +88,7 @@ Envelope wraps an Event and adds metadata.
  
 
 
-<a name="events-Envelope-EventType"></a>
+<a name="events.Envelope.EventType"></a>
 
 ### Envelope.EventType
 Type of the wrapped event.
@@ -111,14 +111,14 @@ Type of the wrapped event.
 
 
 
-<a name="error-proto"></a>
+<a name="events/error.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## error.proto
+## events/error.proto
 
 
 
-<a name="events-Error"></a>
+<a name="events.Error"></a>
 
 ### Error
 An Error event represents an error in the originating process.
@@ -144,14 +144,14 @@ An Error event represents an error in the originating process.
 
 
 
-<a name="http-proto"></a>
+<a name="events/http.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## http.proto
+## events/http.proto
 
 
 
-<a name="events-HttpStartStop"></a>
+<a name="events.HttpStartStop"></a>
 
 ### HttpStartStop
 An HttpStartStop event represents the whole lifecycle of an HTTP request.
@@ -161,15 +161,15 @@ An HttpStartStop event represents the whole lifecycle of an HTTP request.
 | ----- | ---- | ----- | ----------- |
 | startTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was sent (by a client) or received (by a server). |
 | stopTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was received. |
-| requestId | [UUID](#events-UUID) | required | ID for tracking lifecycle of request. |
-| peerType | [PeerType](#events-PeerType) | required | Role of the emitting process in the request cycle. |
-| method | [Method](#events-Method) | required | Method of the request. |
+| requestId | [UUID](#events.UUID) | required | ID for tracking lifecycle of request. |
+| peerType | [PeerType](#events.PeerType) | required | Role of the emitting process in the request cycle. |
+| method | [Method](#events.Method) | required | Method of the request. |
 | uri | [string](#string) | required | Destination of the request. |
 | remoteAddress | [string](#string) | required | Remote address of the request. (For a server, this should be the origin of the request.) |
 | userAgent | [string](#string) | required | Contents of the UserAgent header on the request. |
 | statusCode | [int32](#int32) | required | Status code returned with the response to the request. |
 | contentLength | [int64](#int64) | required | Length of response (bytes). |
-| applicationId | [UUID](#events-UUID) | optional | If this request was made in relation to an appliciation, this field should track that application&#39;s ID. |
+| applicationId | [UUID](#events.UUID) | optional | If this request was made in relation to an appliciation, this field should track that application&#39;s ID. |
 | instanceIndex | [int32](#int32) | optional | Index of the application instance. |
 | instanceId | [string](#string) | optional | ID of the application instance. |
 | forwarded | [string](#string) | repeated | This contains http forwarded-for [x-forwarded-for] header from the request. |
@@ -181,7 +181,7 @@ An HttpStartStop event represents the whole lifecycle of an HTTP request.
  
 
 
-<a name="events-Method"></a>
+<a name="events.Method"></a>
 
 ### Method
 HTTP method.
@@ -235,7 +235,7 @@ HTTP method.
 
 
 
-<a name="events-PeerType"></a>
+<a name="events.PeerType"></a>
 
 ### PeerType
 Type of peer handling request.
@@ -254,14 +254,14 @@ Type of peer handling request.
 
 
 
-<a name="log-proto"></a>
+<a name="events/log.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## log.proto
+## events/log.proto
 
 
 
-<a name="events-LogMessage"></a>
+<a name="events.LogMessage"></a>
 
 ### LogMessage
 A LogMessage contains a &#34;log line&#34; and associated metadata.
@@ -270,7 +270,7 @@ A LogMessage contains a &#34;log line&#34; and associated metadata.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | message | [bytes](#bytes) | required | Bytes of the log message. (Note that it is not required to be a single line.) |
-| message_type | [LogMessage.MessageType](#events-LogMessage-MessageType) | required | Type of the message (OUT or ERR). |
+| message_type | [LogMessage.MessageType](#events.LogMessage.MessageType) | required | Type of the message (OUT or ERR). |
 | timestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the log was written. |
 | app_id | [string](#string) | optional | Application that emitted the message (or to which the application is related). |
 | source_type | [string](#string) | optional | Source of the message. For Cloud Foundry, this can be &#34;APP&#34;, &#34;RTR&#34;, &#34;DEA&#34;, &#34;STG&#34;, etc. |
@@ -283,7 +283,7 @@ A LogMessage contains a &#34;log line&#34; and associated metadata.
  
 
 
-<a name="events-LogMessage-MessageType"></a>
+<a name="events.LogMessage.MessageType"></a>
 
 ### LogMessage.MessageType
 MessageType stores the destination of the message (corresponding to STDOUT or STDERR).
@@ -302,14 +302,14 @@ MessageType stores the destination of the message (corresponding to STDOUT or ST
 
 
 
-<a name="metric-proto"></a>
+<a name="events/metric.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## metric.proto
+## events/metric.proto
 
 
 
-<a name="events-ContainerMetric"></a>
+<a name="events.ContainerMetric"></a>
 
 ### ContainerMetric
 A ContainerMetric records resource usage of an app in a container.
@@ -330,7 +330,7 @@ A ContainerMetric records resource usage of an app in a container.
 
 
 
-<a name="events-CounterEvent"></a>
+<a name="events.CounterEvent"></a>
 
 ### CounterEvent
 A CounterEvent represents the increment of a counter. It contains only the
@@ -349,7 +349,7 @@ maintain the value of the counter.
 
 
 
-<a name="events-ValueMetric"></a>
+<a name="events.ValueMetric"></a>
 
 ### ValueMetric
 A ValueMetric indicates the value of a metric at an instant in time.
@@ -375,14 +375,14 @@ A ValueMetric indicates the value of a metric at an instant in time.
 
 
 
-<a name="uuid-proto"></a>
+<a name="events/uuid.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## uuid.proto
+## events/uuid.proto
 
 
 
-<a name="events-UUID"></a>
+<a name="events.UUID"></a>
 
 ### UUID
 Type representing a 128-bit UUID.

--- a/events/README.md
+++ b/events/README.md
@@ -3,46 +3,46 @@
 
 ## Table of Contents
 
-- [events/envelope.proto](#events/envelope.proto)
-    - [Envelope](#events.Envelope)
-    - [Envelope.TagsEntry](#events.Envelope.TagsEntry)
+- [dropsonde-protocol/events/envelope.proto](#dropsonde-protocol_events_envelope-proto)
+    - [Envelope](#events-Envelope)
+    - [Envelope.TagsEntry](#events-Envelope-TagsEntry)
   
-    - [Envelope.EventType](#events.Envelope.EventType)
+    - [Envelope.EventType](#events-Envelope-EventType)
   
-- [events/error.proto](#events/error.proto)
-    - [Error](#events.Error)
+- [dropsonde-protocol/events/error.proto](#dropsonde-protocol_events_error-proto)
+    - [Error](#events-Error)
   
-- [events/http.proto](#events/http.proto)
-    - [HttpStartStop](#events.HttpStartStop)
+- [dropsonde-protocol/events/http.proto](#dropsonde-protocol_events_http-proto)
+    - [HttpStartStop](#events-HttpStartStop)
   
-    - [Method](#events.Method)
-    - [PeerType](#events.PeerType)
+    - [Method](#events-Method)
+    - [PeerType](#events-PeerType)
   
-- [events/log.proto](#events/log.proto)
-    - [LogMessage](#events.LogMessage)
+- [dropsonde-protocol/events/log.proto](#dropsonde-protocol_events_log-proto)
+    - [LogMessage](#events-LogMessage)
   
-    - [LogMessage.MessageType](#events.LogMessage.MessageType)
+    - [LogMessage.MessageType](#events-LogMessage-MessageType)
   
-- [events/metric.proto](#events/metric.proto)
-    - [ContainerMetric](#events.ContainerMetric)
-    - [CounterEvent](#events.CounterEvent)
-    - [ValueMetric](#events.ValueMetric)
+- [dropsonde-protocol/events/metric.proto](#dropsonde-protocol_events_metric-proto)
+    - [ContainerMetric](#events-ContainerMetric)
+    - [CounterEvent](#events-CounterEvent)
+    - [ValueMetric](#events-ValueMetric)
   
-- [events/uuid.proto](#events/uuid.proto)
-    - [UUID](#events.UUID)
+- [dropsonde-protocol/events/uuid.proto](#dropsonde-protocol_events_uuid-proto)
+    - [UUID](#events-UUID)
   
 - [Scalar Value Types](#scalar-value-types)
 
 
 
-<a name="events/envelope.proto"></a>
+<a name="dropsonde-protocol_events_envelope-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/envelope.proto
+## dropsonde-protocol/events/envelope.proto
 
 
 
-<a name="events.Envelope"></a>
+<a name="events-Envelope"></a>
 
 ### Envelope
 Envelope wraps an Event and adds metadata.
@@ -51,26 +51,26 @@ Envelope wraps an Event and adds metadata.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | origin | [string](#string) | required | Unique description of the origin of this event. |
-| eventType | [Envelope.EventType](#events.Envelope.EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
+| eventType | [Envelope.EventType](#events-Envelope-EventType) | required | Type of wrapped event. Only the optional field corresponding to the value of eventType should be set. |
 | timestamp | [int64](#int64) | optional | UNIX timestamp (in nanoseconds) event was wrapped in this Envelope. |
 | deployment | [string](#string) | optional | Deployment name (used to uniquely identify source). |
 | job | [string](#string) | optional | Job name (used to uniquely identify source). |
 | index | [string](#string) | optional | Index of job (used to uniquely identify source). |
 | ip | [string](#string) | optional | IP address (used to uniquely identify source). |
-| tags | [Envelope.TagsEntry](#events.Envelope.TagsEntry) | repeated | key/value tags to include additional identifying information. |
-| httpStartStop | [HttpStartStop](#events.HttpStartStop) | optional |  |
-| logMessage | [LogMessage](#events.LogMessage) | optional |  |
-| valueMetric | [ValueMetric](#events.ValueMetric) | optional |  |
-| counterEvent | [CounterEvent](#events.CounterEvent) | optional |  |
-| error | [Error](#events.Error) | optional |  |
-| containerMetric | [ContainerMetric](#events.ContainerMetric) | optional |  |
+| tags | [Envelope.TagsEntry](#events-Envelope-TagsEntry) | repeated | key/value tags to include additional identifying information. |
+| httpStartStop | [HttpStartStop](#events-HttpStartStop) | optional |  |
+| logMessage | [LogMessage](#events-LogMessage) | optional |  |
+| valueMetric | [ValueMetric](#events-ValueMetric) | optional |  |
+| counterEvent | [CounterEvent](#events-CounterEvent) | optional |  |
+| error | [Error](#events-Error) | optional |  |
+| containerMetric | [ContainerMetric](#events-ContainerMetric) | optional |  |
 
 
 
 
 
 
-<a name="events.Envelope.TagsEntry"></a>
+<a name="events-Envelope-TagsEntry"></a>
 
 ### Envelope.TagsEntry
 
@@ -88,7 +88,7 @@ Envelope wraps an Event and adds metadata.
  
 
 
-<a name="events.Envelope.EventType"></a>
+<a name="events-Envelope-EventType"></a>
 
 ### Envelope.EventType
 Type of the wrapped event.
@@ -111,14 +111,14 @@ Type of the wrapped event.
 
 
 
-<a name="events/error.proto"></a>
+<a name="dropsonde-protocol_events_error-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/error.proto
+## dropsonde-protocol/events/error.proto
 
 
 
-<a name="events.Error"></a>
+<a name="events-Error"></a>
 
 ### Error
 An Error event represents an error in the originating process.
@@ -144,14 +144,14 @@ An Error event represents an error in the originating process.
 
 
 
-<a name="events/http.proto"></a>
+<a name="dropsonde-protocol_events_http-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/http.proto
+## dropsonde-protocol/events/http.proto
 
 
 
-<a name="events.HttpStartStop"></a>
+<a name="events-HttpStartStop"></a>
 
 ### HttpStartStop
 An HttpStartStop event represents the whole lifecycle of an HTTP request.
@@ -161,15 +161,15 @@ An HttpStartStop event represents the whole lifecycle of an HTTP request.
 | ----- | ---- | ----- | ----------- |
 | startTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was sent (by a client) or received (by a server). |
 | stopTimestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the request was received. |
-| requestId | [UUID](#events.UUID) | required | ID for tracking lifecycle of request. |
-| peerType | [PeerType](#events.PeerType) | required | Role of the emitting process in the request cycle. |
-| method | [Method](#events.Method) | required | Method of the request. |
+| requestId | [UUID](#events-UUID) | required | ID for tracking lifecycle of request. |
+| peerType | [PeerType](#events-PeerType) | required | Role of the emitting process in the request cycle. |
+| method | [Method](#events-Method) | required | Method of the request. |
 | uri | [string](#string) | required | Destination of the request. |
 | remoteAddress | [string](#string) | required | Remote address of the request. (For a server, this should be the origin of the request.) |
 | userAgent | [string](#string) | required | Contents of the UserAgent header on the request. |
 | statusCode | [int32](#int32) | required | Status code returned with the response to the request. |
 | contentLength | [int64](#int64) | required | Length of response (bytes). |
-| applicationId | [UUID](#events.UUID) | optional | If this request was made in relation to an appliciation, this field should track that application&#39;s ID. |
+| applicationId | [UUID](#events-UUID) | optional | If this request was made in relation to an appliciation, this field should track that application&#39;s ID. |
 | instanceIndex | [int32](#int32) | optional | Index of the application instance. |
 | instanceId | [string](#string) | optional | ID of the application instance. |
 | forwarded | [string](#string) | repeated | This contains http forwarded-for [x-forwarded-for] header from the request. |
@@ -181,7 +181,7 @@ An HttpStartStop event represents the whole lifecycle of an HTTP request.
  
 
 
-<a name="events.Method"></a>
+<a name="events-Method"></a>
 
 ### Method
 HTTP method.
@@ -235,7 +235,7 @@ HTTP method.
 
 
 
-<a name="events.PeerType"></a>
+<a name="events-PeerType"></a>
 
 ### PeerType
 Type of peer handling request.
@@ -254,14 +254,14 @@ Type of peer handling request.
 
 
 
-<a name="events/log.proto"></a>
+<a name="dropsonde-protocol_events_log-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/log.proto
+## dropsonde-protocol/events/log.proto
 
 
 
-<a name="events.LogMessage"></a>
+<a name="events-LogMessage"></a>
 
 ### LogMessage
 A LogMessage contains a &#34;log line&#34; and associated metadata.
@@ -270,7 +270,7 @@ A LogMessage contains a &#34;log line&#34; and associated metadata.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | message | [bytes](#bytes) | required | Bytes of the log message. (Note that it is not required to be a single line.) |
-| message_type | [LogMessage.MessageType](#events.LogMessage.MessageType) | required | Type of the message (OUT or ERR). |
+| message_type | [LogMessage.MessageType](#events-LogMessage-MessageType) | required | Type of the message (OUT or ERR). |
 | timestamp | [int64](#int64) | required | UNIX timestamp (in nanoseconds) when the log was written. |
 | app_id | [string](#string) | optional | Application that emitted the message (or to which the application is related). |
 | source_type | [string](#string) | optional | Source of the message. For Cloud Foundry, this can be &#34;APP&#34;, &#34;RTR&#34;, &#34;DEA&#34;, &#34;STG&#34;, etc. |
@@ -283,7 +283,7 @@ A LogMessage contains a &#34;log line&#34; and associated metadata.
  
 
 
-<a name="events.LogMessage.MessageType"></a>
+<a name="events-LogMessage-MessageType"></a>
 
 ### LogMessage.MessageType
 MessageType stores the destination of the message (corresponding to STDOUT or STDERR).
@@ -302,14 +302,14 @@ MessageType stores the destination of the message (corresponding to STDOUT or ST
 
 
 
-<a name="events/metric.proto"></a>
+<a name="dropsonde-protocol_events_metric-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/metric.proto
+## dropsonde-protocol/events/metric.proto
 
 
 
-<a name="events.ContainerMetric"></a>
+<a name="events-ContainerMetric"></a>
 
 ### ContainerMetric
 A ContainerMetric records resource usage of an app in a container.
@@ -330,7 +330,7 @@ A ContainerMetric records resource usage of an app in a container.
 
 
 
-<a name="events.CounterEvent"></a>
+<a name="events-CounterEvent"></a>
 
 ### CounterEvent
 A CounterEvent represents the increment of a counter. It contains only the
@@ -349,7 +349,7 @@ maintain the value of the counter.
 
 
 
-<a name="events.ValueMetric"></a>
+<a name="events-ValueMetric"></a>
 
 ### ValueMetric
 A ValueMetric indicates the value of a metric at an instant in time.
@@ -375,14 +375,14 @@ A ValueMetric indicates the value of a metric at an instant in time.
 
 
 
-<a name="events/uuid.proto"></a>
+<a name="dropsonde-protocol_events_uuid-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## events/uuid.proto
+## dropsonde-protocol/events/uuid.proto
 
 
 
-<a name="events.UUID"></a>
+<a name="events-UUID"></a>
 
 ### UUID
 Type representing a 128-bit UUID.

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -7,10 +7,10 @@ option go_package = "github.com/cloudfoundry/sonde-go/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "EventFactory";
 
-import "http.proto";
-import "log.proto";
-import "metric.proto";
-import "error.proto";
+import "events/http.proto";
+import "events/log.proto";
+import "events/metric.proto";
+import "events/error.proto";
 
 // Envelope wraps an Event and adds metadata.
 message Envelope {

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -1,4 +1,9 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
+
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "EventFactory";
 

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -7,10 +7,10 @@ option go_package = "github.com/cloudfoundry/sonde-go/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "EventFactory";
 
-import "events/http.proto";
-import "events/log.proto";
-import "events/metric.proto";
-import "events/error.proto";
+import "dropsonde-protocol/events/http.proto";
+import "dropsonde-protocol/events/log.proto";
+import "dropsonde-protocol/events/metric.proto";
+import "dropsonde-protocol/events/error.proto";
 
 // Envelope wraps an Event and adds metadata.
 message Envelope {

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "EventFactory";

--- a/events/envelope.proto
+++ b/events/envelope.proto
@@ -12,13 +12,12 @@ import "log.proto";
 import "metric.proto";
 import "error.proto";
 
-/// Envelope wraps an Event and adds metadata.
+// Envelope wraps an Event and adds metadata.
 message Envelope {
-    /// Type of the wrapped event.
+    // Type of the wrapped event.
     enum EventType {
-        // Removed Heartbeat at position 1
-        // Removed HttpStart at position 2
-        // Removed HttpStop at position 3
+        reserved 1 to 3;
+        reserved "Heartbeat", "HttpStart", "HttpStop";
         HttpStartStop = 4;
         LogMessage = 5;
         ValueMetric = 6;
@@ -27,21 +26,34 @@ message Envelope {
         ContainerMetric = 9;
     }
 
-    required string origin = 1;               /// Unique description of the origin of this event.
-    required EventType eventType = 2;         /// Type of wrapped event. Only the optional field corresponding to the value of eventType should be set.
+    // Unique description of the origin of this event.
+    required string origin = 1;
 
-    optional int64 timestamp = 6;             /// UNIX timestamp (in nanoseconds) event was wrapped in this Envelope.
+    // Type of wrapped event. Only the optional field corresponding to the
+    // value of eventType should be set.
+    required EventType eventType = 2;
 
-    optional string deployment = 13;          /// Deployment name (used to uniquely identify source).
-    optional string job = 14;                 /// Job name (used to uniquely identify source).
-    optional string index = 15;               /// Index of job (used to uniquely identify source).
-    optional string ip = 16;                  /// IP address (used to uniquely identify source).
+    // UNIX timestamp (in nanoseconds) event was wrapped in this Envelope.
+    optional int64 timestamp = 6;
 
-    map<string, string> tags = 17;            /// key/value tags to include additional identifying information.
+    // Deployment name (used to uniquely identify source).
+    optional string deployment = 13;
 
-    // Removed Heartbeat at position 3
-    // Removed HttpStart at position 4
-    // Removed HttpStop at position 5
+    // Job name (used to uniquely identify source).
+    optional string job = 14;
+
+    // Index of job (used to uniquely identify source).
+    optional string index = 15;
+
+    // IP address (used to uniquely identify source).
+    optional string ip = 16;
+
+    // key/value tags to include additional identifying information.
+    map<string, string> tags = 17;
+
+    reserved 3 to 5;
+    reserved "Heartbeat", "HttpStart", "HttpStop";
+
     optional HttpStartStop httpStartStop = 7;
     optional LogMessage logMessage = 8;
     optional ValueMetric valueMetric = 9;
@@ -49,4 +61,3 @@ message Envelope {
     optional Error error = 11;
     optional ContainerMetric containerMetric = 12;
 }
-

--- a/events/error.proto
+++ b/events/error.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "ErrorFactory";

--- a/events/error.proto
+++ b/events/error.proto
@@ -1,4 +1,8 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "ErrorFactory";

--- a/events/error.proto
+++ b/events/error.proto
@@ -7,9 +7,16 @@ option go_package = "github.com/cloudfoundry/dropsonde/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "ErrorFactory";
 
-/// An Error event represents an error in the originating process.
+// An Error event represents an error in the originating process.
 message Error {
-    required string source = 1;  /// Source of the error. This may or may not be the same as the Origin in the envelope.
-    required int32 code = 2;     /// Numeric error code. This is provided for programmatic responses to the error.
-    required string message = 3; /// Error description (preferably human-readable).
+    // Source of the error. This may or may not be the same as the Origin in
+    // the envelope.
+    required string source = 1;
+
+    // Numeric error code. This is provided for programmatic responses to the
+    // error.
+    required int32 code = 2;
+
+    // Error description (preferably human-readable).
+    required string message = 3;
 }

--- a/events/http.proto
+++ b/events/http.proto
@@ -9,13 +9,16 @@ option java_outer_classname = "HttpFactory";
 
 import "uuid.proto";
 
-/// Type of peer handling request.
+// Type of peer handling request.
 enum PeerType {
-    Client = 1; /// Request is made by this process.
-    Server = 2; /// Request is received by this process.
+    // Request is made by this process.
+    Client = 1;
+
+    // Request is received by this process.
+    Server = 2;
 }
 
-/// HTTP method.
+// HTTP method.
 enum Method {
     GET = 1;
     POST = 2;
@@ -64,25 +67,54 @@ enum Method {
     VERSION_CONTROL = 44;
 }
 
-/// An HttpStartStop event represents the whole lifecycle of an HTTP request.
+// An HttpStartStop event represents the whole lifecycle of an HTTP request.
 message HttpStartStop {
-    required int64 startTimestamp = 1;  /// UNIX timestamp (in nanoseconds) when the request was sent (by a client) or received (by a server).
-    required int64 stopTimestamp = 2;   /// UNIX timestamp (in nanoseconds) when the request was received.
+    // UNIX timestamp (in nanoseconds) when the request was sent (by a client)
+    // or received (by a server).
+    required int64 startTimestamp = 1;
 
-    required UUID requestId = 3;        /// ID for tracking lifecycle of request.
-    required PeerType peerType = 4;     /// Role of the emitting process in the request cycle.
-    required Method method = 5;         /// Method of the request.
-    required string uri = 6;            /// Destination of the request.
-    required string remoteAddress = 7;  /// Remote address of the request. (For a server, this should be the origin of the request.)
-    required string userAgent = 8;      /// Contents of the UserAgent header on the request.
+    // UNIX timestamp (in nanoseconds) when the request was received.
+    required int64 stopTimestamp = 2;
 
-    required int32 statusCode = 9;      /// Status code returned with the response to the request.
-    required int64 contentLength = 10;  /// Length of response (bytes).
+    // ID for tracking lifecycle of request.
+    required UUID requestId = 3;
 
-    /// 11 used to be ParentRequestID which has been deprecated.
+    // Role of the emitting process in the request cycle.
+    required PeerType peerType = 4;
 
-    optional UUID applicationId = 12;   /// If this request was made in relation to an appliciation, this field should track that application's ID.
-    optional int32 instanceIndex = 13;  /// Index of the application instance.
-    optional string instanceId = 14;    /// ID of the application instance.
-    repeated string forwarded = 15;     /// This contains http forwarded-for [x-forwarded-for] header from the request.
+    // Method of the request.
+    required Method method = 5;
+
+    // Destination of the request.
+    required string uri = 6;
+
+    // Remote address of the request. (For a server, this should be the origin
+    // of the request.)
+    required string remoteAddress = 7;
+
+    // Contents of the UserAgent header on the request.
+    required string userAgent = 8;
+
+    // Status code returned with the response to the request.
+    required int32 statusCode = 9;
+
+    // Length of response (bytes).
+    required int64 contentLength = 10;
+
+    reserved 11;
+    reserved "parentRequestId";
+
+    // If this request was made in relation to an appliciation, this field
+    // should track that application's ID.
+    optional UUID applicationId = 12;
+
+     // Index of the application instance.
+    optional int32 instanceIndex = 13;
+
+    // ID of the application instance.
+    optional string instanceId = 14;
+
+    // This contains http forwarded-for [x-forwarded-for] header from the
+    // request.
+    repeated string forwarded = 15;
 }

--- a/events/http.proto
+++ b/events/http.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "HttpFactory";

--- a/events/http.proto
+++ b/events/http.proto
@@ -1,4 +1,8 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "HttpFactory";

--- a/events/http.proto
+++ b/events/http.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/cloudfoundry/sonde-go/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "HttpFactory";
 
-import "uuid.proto";
+import "events/uuid.proto";
 
 // Type of peer handling request.
 enum PeerType {

--- a/events/http.proto
+++ b/events/http.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/cloudfoundry/sonde-go/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "HttpFactory";
 
-import "events/uuid.proto";
+import "dropsonde-protocol/events/uuid.proto";
 
 // Type of peer handling request.
 enum PeerType {

--- a/events/log.proto
+++ b/events/log.proto
@@ -1,4 +1,8 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "LogFactory";

--- a/events/log.proto
+++ b/events/log.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "LogFactory";

--- a/events/log.proto
+++ b/events/log.proto
@@ -7,19 +7,29 @@ option go_package = "github.com/cloudfoundry/dropsonde/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "LogFactory";
 
-/// A LogMessage contains a "log line" and associated metadata.
+// A LogMessage contains a "log line" and associated metadata.
 message LogMessage {
-
-    /// MessageType stores the destination of the message (corresponding to STDOUT or STDERR).
+    // MessageType stores the destination of the message (corresponding to STDOUT or STDERR).
     enum MessageType {
         OUT = 1;
         ERR = 2;
     }
 
-    required bytes message = 1;            /// Bytes of the log message. (Note that it is not required to be a single line.)
-    required MessageType message_type = 2; /// Type of the message (OUT or ERR).
-    required int64 timestamp = 3;          /// UNIX timestamp (in nanoseconds) when the log was written.
-    optional string app_id = 4;            /// Application that emitted the message (or to which the application is related).
-    optional string source_type = 5;       /// Source of the message. For Cloud Foundry, this can be "APP", "RTR", "DEA", "STG", etc.
-    optional string source_instance = 6;   /// Instance that emitted the message.
+    // Bytes of the log message. (Note that it is not required to be a single line.)
+    required bytes message = 1;
+
+    // Type of the message (OUT or ERR).
+    required MessageType message_type = 2;
+
+    // UNIX timestamp (in nanoseconds) when the log was written.
+    required int64 timestamp = 3;
+
+     // Application that emitted the message (or to which the application is related).
+    optional string app_id = 4;
+
+    // Source of the message. For Cloud Foundry, this can be "APP", "RTR", "DEA", "STG", etc.
+    optional string source_type = 5;
+
+    // Instance that emitted the message.
+    optional string source_instance = 6;
 }

--- a/events/metric.proto
+++ b/events/metric.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "MetricFactory";

--- a/events/metric.proto
+++ b/events/metric.proto
@@ -1,4 +1,8 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "MetricFactory";

--- a/events/metric.proto
+++ b/events/metric.proto
@@ -7,30 +7,59 @@ option go_package = "github.com/cloudfoundry/dropsonde/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "MetricFactory";
 
-import "uuid.proto";
-
-/// A ValueMetric indicates the value of a metric at an instant in time.
+// A ValueMetric indicates the value of a metric at an instant in time.
 message ValueMetric {
-    required string name = 1;  /// Name of the metric. Must be consistent for downstream consumers to associate events semantically.
-    required double value = 2; /// Value at the time of event emission.
-    required string unit = 3;  /// Unit of the metric. Please see http://metrics20.org/spec/#units for ideas; SI units/prefixes are recommended where applicable. Should be consistent for the life of the metric (consumers are expected to report, but not interpret, prefixes).
+    // Name of the metric. Must be consistent for downstream consumers to
+    // associate events semantically.
+    required string name = 1;
+
+    // Value at the time of event emission.
+    required double value = 2;
+
+    // Unit of the metric. Please see http://metrics20.org/spec/#units for
+    // ideas; SI units/prefixes are recommended where applicable. Should be
+    // consistent for the life of the metric (consumers are expected to report,
+    // but not interpret, prefixes).
+    required string unit = 3;
 }
 
-/// A CounterEvent represents the increment of a counter. It contains only the change in the value; it is the responsibility of downstream consumers to maintain the value of the counter.
+// A CounterEvent represents the increment of a counter. It contains only the
+// change in the value; it is the responsibility of downstream consumers to
+// maintain the value of the counter.
 message CounterEvent {
-    required string name = 1;  /// Name of the counter. Must be consistent for downstream consumers to associate events semantically.
-    required uint64 delta = 2; /// Amount by which to increment the counter.
-    optional uint64 total = 3; /// Total value of the counter. This will be overridden by Metron, which internally tracks the total of each named Counter it receives.
+    // Name of the counter. Must be consistent for downstream consumers to
+    // associate events semantically.
+    required string name = 1;
+
+    // Amount by which to increment the counter.
+    required uint64 delta = 2;
+
+    // Total value of the counter. This will be overridden by Metron, which
+    // internally tracks the total of each named Counter it receives.
+    optional uint64 total = 3;
 }
 
-/// A ContainerMetric records resource usage of an app in a container.
+// A ContainerMetric records resource usage of an app in a container.
  message ContainerMetric {
-    required string applicationId = 1; /// ID of the contained application.
-    required int32 instanceIndex = 2;  /// Instance index of the contained application. (This, with applicationId, should uniquely identify a container.)
+     // ID of the contained application.
+    required string applicationId = 1;
 
-    required double cpuPercentage = 3;    /// CPU based on number of cores.
-    required uint64 memoryBytes = 4;      /// Bytes of memory used.
-    required uint64 diskBytes = 5;        /// Bytes of disk used.
-    optional uint64 memoryBytesQuota = 6; /// Maximum bytes of memory allocated to container.
-    optional uint64 diskBytesQuota = 7;   /// Maximum bytes of disk allocated to container.
+    // Instance index of the contained application. (This, with applicationId,
+    // should uniquely identify a container.)
+    required int32 instanceIndex = 2;
+
+    // CPU based on number of cores.
+    required double cpuPercentage = 3;
+
+    // Bytes of memory used.
+    required uint64 memoryBytes = 4;
+
+    // Bytes of disk used.
+    required uint64 diskBytes = 5;
+
+    // Maximum bytes of memory allocated to container.
+    optional uint64 memoryBytesQuota = 6;
+
+    // Maximum bytes of disk allocated to container.
+    optional uint64 diskBytesQuota = 7;
  }

--- a/events/uuid.proto
+++ b/events/uuid.proto
@@ -1,4 +1,8 @@
+syntax = "proto2";
+
 package events;
+
+option go_package = "github.com/cloudfoundry/dropsonde/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "UuidFactory";

--- a/events/uuid.proto
+++ b/events/uuid.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 
 package events;
 
-option go_package = "github.com/cloudfoundry/dropsonde/events";
+option go_package = "github.com/cloudfoundry/sonde-go/events";
 
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "UuidFactory";

--- a/events/uuid.proto
+++ b/events/uuid.proto
@@ -7,9 +7,11 @@ option go_package = "github.com/cloudfoundry/dropsonde/events";
 option java_package = "org.cloudfoundry.dropsonde.events";
 option java_outer_classname = "UuidFactory";
 
-/// Type representing a 128-bit UUID.
+// Type representing a 128-bit UUID.
 //
-// The bytes of the UUID should be packed in little-endian **byte** (not bit) order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
+// The bytes of the UUID should be packed in little-endian **byte** (not bit)
+// order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should
+// be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
 message UUID {
     required uint64 low = 1;
     required uint64 high = 2;


### PR DESCRIPTION
* Add `proto2` syntax definitions
* Add `go_package` option for generating go files
* Update comments (`//` instead of `///`, keep within 80 lines)
* ~~Use `CAPITALS_WITH_UNDERSCORES` for enums~~
* ~~Use `underscore_separated_names` for field names~~
* Regenerate events/README.md
* Update README.md